### PR TITLE
Return error when required values are None

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -103,12 +103,12 @@ impl Search {
 
     /// Runs the search.
     pub fn search(&self) -> Result<SearchResults> {
-        // TODO Return error if search_area or query are None
-        if self.search_area == None || self.query == None {
-            return Err(Box::new(SearchError("Please provide search area and query".into())))
+        if let (Some(_), Some(_)) = (self.search_area.as_ref(), self.query.as_ref()) {
+            let results: SearchResults = reqwest::get(&self.to_string())?.json()?;
+            Ok(results)
+        } else {
+            Err(Box::new(SearchError("Please provide search area and query by using Search::new()".into())))
         }
-        let results: SearchResults = reqwest::get(&self.to_string())?.json()?;
-        Ok(results)
     }
 }
 


### PR DESCRIPTION
Defines an Error type for Search and returns it when search area or query are none. This addresses #5.

I have to admit to StackOverflow-ing the error type definition. I don't know if an `enum` with more differentiated error types would be better and more future proof here.